### PR TITLE
.NET 4.6.2 Compatibility

### DIFF
--- a/Harmony/Tools/DynamicTools.cs
+++ b/Harmony/Tools/DynamicTools.cs
@@ -97,7 +97,13 @@ namespace Harmony
 				var m_GetMethodDescriptor = typeof(DynamicMethod).GetMethod("GetMethodDescriptor", BindingFlags.NonPublic | BindingFlags.Instance);
 				var m__CompileMethod = typeof(RuntimeHelpers).GetMethod("_CompileMethod", BindingFlags.NonPublic | BindingFlags.Static);
 				RuntimeMethodHandle handle = (RuntimeMethodHandle)m_GetMethodDescriptor.Invoke(method, new object[0]);
-				if (m__CompileMethod.GetParameters()[0].ParameterType == typeof(IntPtr))
+				var m_GetMethodInfo = typeof(RuntimeMethodHandle).GetMethod("GetMethodInfo", BindingFlags.NonPublic | BindingFlags.Instance);
+				if (m_GetMethodInfo != null)
+				{
+					object runtimeMethodInfo = m_GetMethodInfo.Invoke(handle, new object[0]);
+					m__CompileMethod.Invoke(null, new object[] { runtimeMethodInfo });
+				}
+				else if (m__CompileMethod.GetParameters()[0].ParameterType == typeof(IntPtr))
 					m__CompileMethod.Invoke(null, new object[] { handle.Value });
 				else
 					m__CompileMethod.Invoke(null, new object[] { handle });


### PR DESCRIPTION
Harmony wouldn't work on my machine (.NET 4.6.2, Windows 10) without those two changes:

On the one hand, the Signature of RuntimeHelpers._CompileMethod has changed to take an argument of IRuntimeMethodHandle instead of IntPtr previously.
On the other hand, MethodHandle is not supported in DynamicMethod. However calling DynamicMethod.GetMethodDescriptor() actually works.

*Edit*
I'm still unsure on how this should be tested though as the test project references .NET 3.5 for which the existing code works perfectly fine. Maybe there should be a 2nd test project targeting .NET 4.x?